### PR TITLE
Create socket on specific ipv4 address.

### DIFF
--- a/core/actionProxy/actionproxy.py
+++ b/core/actionProxy/actionproxy.py
@@ -263,7 +263,7 @@ def complete(response):
 
 def main():
     port = int(os.getenv('FLASK_PROXY_PORT', 8080))
-    server = WSGIServer(('', port), proxy, log=None)
+    server = WSGIServer(('0.0.0.0', port), proxy, log=None)
     server.serve_forever()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Not being specific here causes python3 to try an ipv6 address first which fails on kernels which do not contain the ipv6 module.