### PR TITLE
new akka client throws IllegalStateException 

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,4 +5,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip

--- a/tests/src/test/scala/runtime/actionContainers/DockerExampleContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/DockerExampleContainerTests.scala
@@ -133,7 +133,7 @@ class DockerExampleContainerTests extends ActionProxyContainerTestUtils with Wsk
 
   it should "timeout bad proxy with exception" in {
     val (out, err) = withContainer("badproxy") { c =>
-      a[TimeoutException] should be thrownBy {
+      a[IllegalStateException] should be thrownBy {
         val (code, out) = c.init(JsObject())
         println(code, out)
       }

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -40,4 +40,6 @@ echo "vcap.services.file=" >> whisk.properties
 
 # Build runtime
 cd $ROOTDIR
+cat ./gradle/wrapper/*.properties
+./gradlew --version
 TERM=dumb ./gradlew distDocker

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-set -e
+set -ex
 
 # Build script for Travis-CI.
 

--- a/tools/travis/test.sh
+++ b/tools/travis/test.sh
@@ -27,4 +27,9 @@ WHISKDIR="$ROOTDIR/../openwhisk"
 export OPENWHISK_HOME=$WHISKDIR
 cd ${ROOTDIR}
 TERM=dumb ./gradlew :tests:checkScalafmtAll
+
+#debugging ActionContainer staleness
+unzip  ~/.m2/repository/org/apache/openwhisk/openwhisk-tests/1.0.0-SNAPSHOT/openwhisk-tests-1.0.0-SNAPSHOT-test-sources.jar actionContainers/ActionContainer.*
+cat actionContainers/ActionContainer.scala
+
 TERM=dumb ./gradlew :tests:test


### PR DESCRIPTION
instead of TimeoutException

This test change should be merged once https://github.com/apache/incubator-openwhisk/pull/3812 is merged (where tests switch to using akka client)