### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Create a zip action with a `exec` in the root of the zip
 ```
 echo \
 '#!/bin/bash
-echo "{\"messag\":\"Hello World\"}"' > exec
+echo "{\"message\":\"Hello World\"}"' > exec
 ```
 ```
 chmod +x exec


### PR DESCRIPTION
README under section 'Give it a try today', contains "messag" instead of "message".